### PR TITLE
Fixed import of signInMethods

### DIFF
--- a/src/projects/authentication/AuthenticationLayout.js
+++ b/src/projects/authentication/AuthenticationLayout.js
@@ -4,7 +4,7 @@ import Panel from '../../ui/Panel'
 import PageHeader from '../../ui/PageHeader'
 import { PageHeaderTabs, Tab } from '../../ui/PageHeaderTabs'
 import Users from './Users'
-import SigninMethods from './SigninMethods'
+import SigninMethods from './SignInMethods'
 import Templates from './Templates'
 
 const AuthenticationLayout = ({ match }) => {


### PR DESCRIPTION
I was studying react router and notice that the import for the SigninMethods wasn't correct, so i fixed it.
Probablye on the next branches the import is still wrong and need to be fixed